### PR TITLE
Fix equal height tiles

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,3 @@
 //= require bootstrap-sprockets
 //= require_tree .
 //
-$(function () {
-  $('#gallery').equalize();
-});

--- a/app/assets/javascripts/equalize.min.js
+++ b/app/assets/javascripts/equalize.min.js
@@ -1,9 +1,0 @@
-/*!
- * equalize.js
- * Author & copyright (c) 2012: Tim Svensen
- * Dual MIT & GPL license
- *
- * Page: http://tsvensen.github.com/equalize.js
- * Repo: https://github.com/tsvensen/equalize.js/
- */
-!function(i){i.fn.equalize=function(e){var n,t,h=!1,c=!1;return i.isPlainObject(e)?(n=e.equalize||"height",h=e.children||!1,c=e.reset||!1):n=e||"height",i.isFunction(i.fn[n])?(t=0<n.indexOf("eight")?"height":"width",this.each(function(){var e=h?i(this).find(h):i(this).children(),s=0;e.each(function(){var e=i(this);c&&e.css(t,""),e=e[n](),e>s&&(s=e)}),e.css(t,s+"px")})):!1}}(jQuery);

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -16,3 +16,8 @@
 
 @import "bootstrap-sprockets"
 @import "bootstrap"
+
+
+.gallery-tiles
+  display: flexbox
+  flex-wrap: wrap

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -19,5 +19,12 @@
 
 
 .gallery-tiles
-  display: flexbox
+  display: flex
   flex-wrap: wrap
+
+.gallery-tiles > *
+  display: flex
+  flex-direction: column
+
+.gallery-tiles .thumbnail
+  flex: 1

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,3 +1,3 @@
-<div class="row" id="gallery">
+<div class="row gallery-tiles" id="gallery">
   <%= render partial: "site", collection: @sites %>
 </div>


### PR DESCRIPTION
The equalize function wasn't working well... tiles were overlapping a lot of the links in the previous row b/c the heights were too small.

I pulled out that lib and added some flexbox to get you equal heights from CSS alone. This will work in browsers for 94+% of users, others will fallback to unequal height tiles.

This is a little bit quick and dirty, but it should get you a step in the right direction.